### PR TITLE
Add read/import of pool name for resource ip_address

### DIFF
--- a/solidserver/resource_ip_address.go
+++ b/solidserver/resource_ip_address.go
@@ -3,12 +3,13 @@ package solidserver
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceipaddress() *schema.Resource {
@@ -405,6 +406,7 @@ func resourceipaddressRead(d *schema.ResourceData, meta interface{}) error {
 			}
 
 			d.Set("class", buf[0]["ip_class_name"].(string))
+			d.Set("pool", buf[0]["pool_name"].(string))
 
 			// Updating local class_parameters
 			currentClassParameters := d.Get("class_parameters").(map[string]interface{})
@@ -466,6 +468,7 @@ func resourceipaddressImportState(d *schema.ResourceData, meta interface{}) ([]*
 			d.Set("name", buf[0]["name"].(string))
 			d.Set("mac", buf[0]["mac_addr"].(string))
 			d.Set("class", buf[0]["ip_class_name"].(string))
+			d.Set("pool", buf[0]["pool_name"].(string))
 
 			// Updating local class_parameters
 			currentClassParameters := d.Get("class_parameters").(map[string]interface{})


### PR DESCRIPTION
When importing an [ip_address](https://registry.terraform.io/providers/EfficientIP-Labs/solidserver/latest/docs/resources/ip_address) the pool parameter is missing. This PR add getting this pool name during import and read.