### PR TITLE
fix solidserverversion regex

### DIFF
--- a/solidserver/provider.go
+++ b/solidserver/provider.go
@@ -48,7 +48,7 @@ func Provider() *schema.Provider {
 				Required:     false,
 				Optional:     true,
 				DefaultFunc:  schema.EnvDefaultFunc("SOLIDServer_VERSION", ""),
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]\.[0-9]\.[0-9]\.([pP][0-9]+[a-z]?)?)?$`), "Invalid Version Number"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([0-9]\.[0-9]\.[0-9]((\.[pP]\d+[a-z]?)|[a-z])?)$`), "Invalid Version Number"),
 				Description:  "SOLIDServer Version in case API user does not have admin permissions",
 			},
 		},


### PR DESCRIPTION
My solid server version **7.3.7** doesn't match with validation Regex.

Currently, here are the validations made : 
**7.3.7 :** doesn't match
**7.3.7. :** match
**7.3.7a :** doesn't match
**7.3.7.P10 :** match
**7.3.7.P10a :** match

With the fix : 
**7.3.7 :** match
**7.3.7.** : doesn't match
**7.3.7a** : match
**7.3.7.P10** : match
**7.3.7.P10a** : match
