### PR TITLE
Support proxy URL in provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,3 +51,4 @@ provider "solidserver" {
 - `solidserverversion` (String) SOLIDServer Version in case API user does not have admin permissions
 - `sslverify` (Boolean) Enable/Disable ssl verify (Default : enabled)
 - `timeout` (Number) API call timeout value in seconds (Default 10s)
+- `proxy_url` (String) URL for a proxy to be used for SOLIDServer connectivity.

--- a/solidserver/provider.go
+++ b/solidserver/provider.go
@@ -65,7 +65,7 @@ func Provider() *schema.Provider {
 				Type:             schema.TypeString,
 				Required:         false,
 				Optional:         true,
-				Default:          schema.EnvDefaultFunc("SOLIDServer_PROXY_URL", ""),
+				DefaultFunc:      schema.EnvDefaultFunc("SOLIDServer_PROXY_URL", ""),
 				Description:      "URL for a proxy to be used for SOLIDServer connectivity. Empty or unspecified means no proxy (direct connectivity). Supported URL schemes are 'http', 'https', and 'socks5'. If the scheme is empty, 'http' is assumed",
 				ValidateDiagFunc: validateProxyURLValue,
 			},

--- a/solidserver/soliderver.go
+++ b/solidserver/soliderver.go
@@ -236,6 +236,10 @@ func (s *SOLIDserver) Request(method string, service string, parameters *url.Val
 	apiclient := gorequest.New()
 	apiclient.Proxy(s.ProxyURL)
 
+	if s.ProxyURL != "" {
+		tflog.Debug(s.Ctx, fmt.Sprintf("Using proxy URL: %q\n", s.ProxyURL))
+	}
+
 	if s.Authenticated == false {
 		apiclient.Retry(3, time.Duration(rand.Intn(15)+1)*time.Second, http.StatusTooManyRequests, http.StatusInternalServerError)
 	} else {

--- a/solidserver/soliderver.go
+++ b/solidserver/soliderver.go
@@ -7,9 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/parnurzeal/gorequest"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -19,6 +16,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/parnurzeal/gorequest"
 )
 
 type HttpRequestFunc func(*gorequest.SuperAgent, string) *gorequest.SuperAgent
@@ -45,9 +46,10 @@ type SOLIDserver struct {
 	Timeout                  int
 	Version                  int
 	Authenticated            bool
+	ProxyURL                 string
 }
 
-func NewSOLIDserver(ctx context.Context, host string, username string, password string, sslverify bool, certsfile string, timeout int, version string) (*SOLIDserver, diag.Diagnostics) {
+func NewSOLIDserver(ctx context.Context, host string, username string, password string, sslverify bool, certsfile string, timeout int, version string, proxyURL string) (*SOLIDserver, diag.Diagnostics) {
 	s := &SOLIDserver{
 		Ctx:                      ctx,
 		Host:                     host,
@@ -59,6 +61,7 @@ func NewSOLIDserver(ctx context.Context, host string, username string, password 
 		Timeout:                  timeout,
 		Version:                  0,
 		Authenticated:            false,
+		ProxyURL:                 proxyURL,
 	}
 
 	if err := s.GetVersion(version); err != nil {
@@ -161,6 +164,7 @@ KeepTrying:
 func (s *SOLIDserver) GetVersion(version string) diag.Diagnostics {
 
 	apiclient := gorequest.New()
+	apiclient.Proxy(s.ProxyURL)
 
 	parameters := url.Values{}
 	parameters.Add("WHERE", "member_is_me='1'")
@@ -230,6 +234,7 @@ func (s *SOLIDserver) Request(method string, service string, parameters *url.Val
 	var err error = nil
 
 	apiclient := gorequest.New()
+	apiclient.Proxy(s.ProxyURL)
 
 	if s.Authenticated == false {
 		apiclient.Retry(3, time.Duration(rand.Intn(15)+1)*time.Second, http.StatusTooManyRequests, http.StatusInternalServerError)


### PR DESCRIPTION
closes: #40 

Add a `proxy_url` attribute on the provider, and pass the given value on `gorequest`'s `SuperAgent`'s `Proxy()`. In order to be able to configure a proxy when making requests to the SOLIDServer API.